### PR TITLE
Add accessors for mutable collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## [Unreleased]
 
-### Scoped and shared fields (#1)
+### Scoped and shared values (#1)
 
-Now there are two types of memory fields: scoped (to class) and shared.
+Now there are two types of memory values: scoped (to class) and shared.
 
-All memory fields by default are scoped to the class where it's declared.
+All memory values by default are scoped to the class where it's declared.
 Scoping prevents from unintended sharing of properties with the same name between classes.
 This snippet demonstrates the problem:
 
@@ -67,6 +67,12 @@ You can just declare a nullable field:
 -var counter: Int by memory.withDefault { 0 }
 +var counter: Int by memory { 0 }
 ```
+
+### Mutable collections accessors
+> **BREAKING CHANGE**
+
+Now accessors `map` and `list` return delegates to access immutable collections.
+You should use `mutableMap` and `mutableList` for mutable versions of collections.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ class CardsInMemoryStorage(memory: MapMemory) {
 
 There are default accessors available:
 
-| Accessor     | Default value | Description           |
-|--------------|---------------|-----------------------|
-| `nullable()` | `null`        | Store nullable values |
-| `map()`      | Empty map     | Store values in map   |
-| `list()`     | Empty list    | Store values in list  |
+| Accessor        | Default value | Description           |
+|-----------------|---------------|-----------------------|
+| `nullable()`    | `null`        | Store nullable values |
+| `map()`         | Empty map     | Store map             |
+| `mutableMap()`  | Empty map     | Store values in map   |
+| `list()`        | Empty list    | Store list            |
+| `mutableList()` | Empty list    | Store values in list  |
 
 You can create own accessor if needed.
 

--- a/mapmemory/src/main/kotlin/MapMemory.kt
+++ b/mapmemory/src/main/kotlin/MapMemory.kt
@@ -28,7 +28,8 @@ import kotlin.reflect.KProperty
  * storage.authToken = "[TOKEN_HERE]"
  * println(memory) // {com.example.TokenStorage#authToken: [TOKEN_HERE]}
  * ```
- * There are a number of delegates to store collections in memory: [map], [list]
+ * There are a number of delegates to store collections in memory:
+ * [map], [mutableMap], [list], [mutableList].
  *
  * You can specify default value using operator [invoke].
  * Default value will used if you're trying to read property before it was written.

--- a/mapmemory/src/main/kotlin/MemoryAccessors.kt
+++ b/mapmemory/src/main/kotlin/MemoryAccessors.kt
@@ -1,41 +1,55 @@
 package com.redmadrobot.mapmemory
 
-import com.redmadrobot.mapmemory.internal.getOrPutProperty
+import com.redmadrobot.mapmemory.internal.getWithNullabilityInference
+import com.redmadrobot.mapmemory.internal.putNotNull
+import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.properties.ReadWriteProperty
-import kotlin.reflect.KProperty
 
 /**
- * Creates a delegate for dealing with nullable values stored in [MapMemory].
- * The delegate returns `null` if there is no corresponding value in memory.
+ * Creates a delegate for dealing with [Map] stored in [MapMemory].
+ * The delegate returns (and stores) empty map if there is no corresponding value in memory.
  */
-public fun <T : Any> MapMemory.nullable(): ReadWriteProperty<Any?, T?> {
-    return object : ReadWriteProperty<Any?, T?> {
-        @Suppress("UNCHECKED_CAST")
-        override fun getValue(thisRef: Any?, property: KProperty<*>): T? = get(property.name) as T?
-
-        override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
-            if (value == null) {
-                remove(property.name)
-            } else {
-                put(property.name, value)
-            }
-        }
-    }
+public fun <K, V> MapMemory.map(): MapMemoryProperty<Map<K, V>> {
+    return invoke { emptyMap() }
 }
 
 /**
  * Creates a delegate for dealing with [MutableMap] stored in [MapMemory].
  * The delegate returns (and stores) empty map if there is no corresponding value in memory.
+ * Uses [ConcurrentHashMap] implementation.
  */
-public fun <K, V> MapMemory.map(): ReadWriteProperty<Any?, MutableMap<K, V>> {
-    return getOrPutProperty { ConcurrentHashMap<K, V>() }
+public fun <K, V> MapMemory.mutableMap(): MapMemoryProperty<MutableMap<K, V>> {
+    return invoke { ConcurrentHashMap<K, V>() }
+}
+
+/**
+ * Creates a delegate for dealing with [List] stored in [MapMemory].
+ * The delegate returns (and stores) empty list if there is no corresponding value in memory.
+ */
+public fun <T> MapMemory.list(): MapMemoryProperty<List<T>> {
+    return invoke { emptyList() }
 }
 
 /**
  * Creates a delegate for dealing with [MutableList] stored in [MapMemory].
  * The delegate returns (and stores) empty list if there is no corresponding value in memory.
+ * Uses synchronized list implementation.
  */
-public fun <T> MapMemory.list(): ReadWriteProperty<Any?, MutableList<T>> {
-    return getOrPutProperty { mutableListOf() }
+public fun <T> MapMemory.mutableList(): MapMemoryProperty<MutableList<T>> {
+    return invoke { Collections.synchronizedList(mutableListOf()) }
+}
+
+/**
+ * Creates a delegate for dealing with nullable values stored in [MapMemory].
+ * The delegate returns `null` if there is no corresponding value in memory.
+ */
+@Deprecated(
+    message = "This accessor is not needed anymore",
+    replaceWith = ReplaceWith("this"),
+)
+public inline fun <reified T : Any> MapMemory.nullable(): MapMemoryProperty<T?> {
+    return object : MapMemoryProperty<T?>() {
+        override fun getValue(key: String): T? = getWithNullabilityInference(key)
+        override fun setValue(key: String, value: T?) = putNotNull(key, value)
+    }
 }


### PR DESCRIPTION

### Removed `.nullable()`

Accessor `nullable()` is not needed now.
You can just declare a nullable field:
```diff
-val selectedOption: String? by memory.nullable()
+val selectedOption: String? by memory
```

### Mutable collections accessors
> **BREAKING CHANGE**

Now accessors `map` and `list` return delegates to access immutable collections.
You should use `mutableMap` and `mutableList` for mutable versions of collections.