### PR TITLE
Kapt bug workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,22 @@ RxJava:
 - `getAllStream` -> `valuesObservable`
 - New field `observable` with the whole map
 
+### KAPT: 'IllegalStateException: Couldn't find declaration file' on delegate with inline getValue operator
+
+There is a bug in Kotlin Compiler that affects MapMemory if you create subclasses - [KT-46317](https://youtrack.jetbrains.com/issue/KT-46317).
+You can use module `mapmemory-kapt-bug-workaround` as a workaround:
+
+```kotlin
+dependencies {
+    implementation("com.redmadrobot.mapmemory:mapmemory-kapt-bug-workaround:[latest-version]")
+}
+```
+
+```diff
+- val someValue: String by memory
++ val someValue: String by memory.value()
+```
+
 ## [2.0-rc1] (2021-03-14)
 
 ### Scoped and shared values (#1)

--- a/README.md
+++ b/README.md
@@ -298,6 +298,22 @@ Keep in mind that you should manually clear `SessionMemory` on logout.
 
 > :memo: Instead of creating subclasses, you can provide MapMemory with [qualifiers].
 
+#### KAPT: 'IllegalStateException: Couldn't find declaration file' on delegate with inline getValue operator
+
+There is the bug in Kotlin Compiler that affects MapMemory if you create subclasses - [KT-46317](https://youtrack.jetbrains.com/issue/KT-46317).
+You can use module `mapmemory-kapt-bug-workaround` as a workaround:
+
+```kotlin
+dependencies {
+    implementation("com.redmadrobot.mapmemory:mapmemory-kapt-bug-workaround:[latest-version]")
+}
+```
+
+```diff
+- val someValue: String by memory
++ val someValue: String by memory.value()
+```
+
 ### Testing
 
 Module `mapmemory-test` provides utilities helping to test code that uses MapMemory.

--- a/mapmemory-kapt-bug-workaround/build.gradle.kts
+++ b/mapmemory-kapt-bug-workaround/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("redmadrobot.kotlin-library")
+    id("redmadrobot.publish")
+    kotlin("kapt")
+}
+
+description = "Workaround for bug in Kotlin compiler when use MapMemory with KAPT"
+
+dependencies {
+    api(project(":mapmemory"))
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")
+}

--- a/mapmemory-kapt-bug-workaround/src/main/kotlin/KaptBugWorkaround.kt
+++ b/mapmemory-kapt-bug-workaround/src/main/kotlin/KaptBugWorkaround.kt
@@ -1,0 +1,18 @@
+package com.redmadrobot.mapmemory
+
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Returns property delegate to deal with value in [this] MapMemory.
+ * Workaround for [KT-46317](https://youtrack.jetbrains.com/issue/KT-46317).
+ */
+public inline fun <reified V> MapMemory.value(): ReadWriteProperty<Any?, V> {
+    return object : ReadWriteProperty<Any?, V> {
+        override fun getValue(thisRef: Any?, property: KProperty<*>): V = this@value.getValue(thisRef, property)
+
+        override fun setValue(thisRef: Any?, property: KProperty<*>, value: V) {
+            this@value.setValue(thisRef, property, value)
+        }
+    }
+}

--- a/mapmemory-kapt-bug-workaround/src/test/kotlin/KaptBugWorkaroundTest.kt
+++ b/mapmemory-kapt-bug-workaround/src/test/kotlin/KaptBugWorkaroundTest.kt
@@ -1,0 +1,21 @@
+@file:Suppress("unused")
+
+package com.redmadrobot.mapmemory
+
+// ----------------------------------------
+// Test is successful if compilation passed
+// ----------------------------------------
+
+// Condition 1. Use subclass from library class which has getValue operator
+class MemorySubclass : MapMemory()
+
+class MemoryConsumer(memory: MemorySubclass) {
+    // Condition 2. Declare property using delegate
+    val delegatedValue: String by memory.value()
+    val delegatedNullableValue: String? by memory.value()
+    // Uncomment to chek if bug in Kotlin Compiler is fixed
+    // val delegatedValueWithBug: String? by memory
+}
+
+// Condition 3. Have kapt enabled and have any dependency with kapt configuration
+// See build.gradle.kts

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,5 +13,6 @@ include(
     "mapmemory-rxjava2",
     "mapmemory-rxjava3",
     "mapmemory-coroutines",
-    "mapmemory-test"
+    "mapmemory-test",
+    "mapmemory-kapt-bug-workaround"
 )


### PR DESCRIPTION
There is a bug in Kotlin Compiler that affects MapMemory if you create subclasses - [KT-46317](https://youtrack.jetbrains.com/issue/KT-46317).
You can use module `mapmemory-kapt-bug-workaround` as a workaround:

```kotlin
dependencies {
    implementation("com.redmadrobot.mapmemory:mapmemory-kapt-bug-workaround:[latest-version]")
}
```

```diff
- val someValue: String by memory
+ val someValue: String by memory.value()
```

Closes #11 