### PR TITLE
Emit initial ReactiveMutableMap value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added parameter `initialMap` to `MapMemory.reactiveMutableMap()` extension
 
+### Fixes
+
+- ReactiveMutableMap: initial empty map is not emitted (#15)
+
 ### Dependencies
 
 - **mapmemory:** Kotlin `1.4.30` → `1.8.10`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Changes
+
+- Added parameter `initialMap` to `MapMemory.reactiveMutableMap()` extension
+
 ### Dependencies
 
 - **mapmemory:** Kotlin `1.4.30` → `1.8.10`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,15 @@
 [versions]
 
 kotlin = "1.8.10"
+coroutines = "1.6.4"
 infrastructure = "0.18"
 junit = "5.9.2"
 
 [libraries]
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
-kotlinx-coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
+kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 rxjava2 = "io.reactivex.rxjava2:rxjava:2.2.21"
 rxjava3 = "io.reactivex.rxjava3:rxjava:3.1.6"
 
@@ -16,6 +18,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+turbine = "app.cash.turbine:turbine:0.12.1"
 
 [bundles]
 

--- a/mapmemory-coroutines/api/mapmemory-coroutines.api
+++ b/mapmemory-coroutines/api/mapmemory-coroutines.api
@@ -40,6 +40,7 @@ public final class com/redmadrobot/mapmemory/ReactiveMutableMapKt {
 	public static final fun getValueFlow (Lcom/redmadrobot/mapmemory/ReactiveMutableMap;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun getValuesFlow (Lcom/redmadrobot/mapmemory/ReactiveMutableMap;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun reactiveMap (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 }
 

--- a/mapmemory-coroutines/build.gradle.kts
+++ b/mapmemory-coroutines/build.gradle.kts
@@ -8,4 +8,8 @@ description = "Coroutines accessors for MapMemory"
 dependencies {
     api(projects.mapmemory)
     api(libs.kotlinx.coroutines)
+
+    testImplementation(libs.bundles.test)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.turbine)
 }

--- a/mapmemory-coroutines/src/main/kotlin/ReactiveMutableMap.kt
+++ b/mapmemory-coroutines/src/main/kotlin/ReactiveMutableMap.kt
@@ -28,6 +28,8 @@ public class ReactiveMutableMap<K, V>(
 
     private val map = map.toMutableMap()
     private val _flow = MutableSharedFlow<Map<K, V>>(replay = 1, onBufferOverflow = DROP_OLDEST)
+        // Emit initial map value
+        .apply { tryEmit(map.toMap()) }
 
     // @formatter:off
     @Synchronized override fun equals(other: Any?): Boolean = map == other

--- a/mapmemory-coroutines/src/main/kotlin/ReactiveMutableMap.kt
+++ b/mapmemory-coroutines/src/main/kotlin/ReactiveMutableMap.kt
@@ -5,10 +5,13 @@ import kotlinx.coroutines.flow.*
 
 /**
  * Creates a delegate for dealing with [ReactiveMutableMap] stored in [MapMemory].
- * The delegate returns (and stores) empty `ReactiveMutableMap` if there is no corresponding value in memory.
+ * The delegate returns (and stores) `ReactiveMutableMap` with [initialMap] inside
+ * if there is no corresponding value in memory.
  */
-public fun <K, V> MapMemory.reactiveMutableMap(): MapMemoryProperty<ReactiveMutableMap<K, V>> {
-    return invoke { ReactiveMutableMap() }
+public fun <K, V> MapMemory.reactiveMutableMap(
+    initialMap: Map<K, V> = emptyMap(),
+): MapMemoryProperty<ReactiveMutableMap<K, V>> {
+    return invoke { ReactiveMutableMap(initialMap) }
 }
 
 /**

--- a/mapmemory-coroutines/src/test/kotlin/ReactiveMutableMapTest.kt
+++ b/mapmemory-coroutines/src/test/kotlin/ReactiveMutableMapTest.kt
@@ -1,0 +1,25 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.redmadrobot.mapmemory
+
+import app.cash.turbine.test
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class ReactiveMutableMapTest {
+
+    private val memory = MapMemory()
+
+    @Test
+    fun `when map initialized - should emit initial value to flow first`() = runTest {
+        val initialMap = mapOf("initial" to 42)
+
+        val map by memory.reactiveMutableMap(initialMap)
+
+        map.flow.test {
+            awaitItem() shouldBe initialMap
+        }
+    }
+}

--- a/mapmemory-rxjava2/api/mapmemory-rxjava2.api
+++ b/mapmemory-rxjava2/api/mapmemory-rxjava2.api
@@ -42,8 +42,8 @@ public final class com/redmadrobot/mapmemory/ReactiveMutableMapKt {
 	public static final fun getValuesObservable (Lcom/redmadrobot/mapmemory/ReactiveMutableMap;)Lio/reactivex/Observable;
 	public static final fun reactiveMap (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static synthetic fun reactiveMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 }
 
 public final class com/redmadrobot/mapmemory/RxAccessorsKt {

--- a/mapmemory-rxjava2/src/main/kotlin/ReactiveMutableMap.kt
+++ b/mapmemory-rxjava2/src/main/kotlin/ReactiveMutableMap.kt
@@ -8,13 +8,14 @@ import io.reactivex.subjects.Subject
 
 /**
  * Creates a delegate for dealing with [ReactiveMutableMap] stored in [MapMemory].
- * The delegate returns (and stores) empty `ReactiveMap` with specified [strategy]
- * if there is no corresponding value in memory.
+ * The delegate returns (and stores) `ReactiveMutableMap` with [initialMap] inside and specified
+ * [strategy] if there is no corresponding value in memory.
  */
 public fun <K, V : Any> MapMemory.reactiveMutableMap(
+    initialMap: Map<K, V>,
     strategy: ReactiveMutableMap.ReplayStrategy = ReactiveMutableMap.ReplayStrategy.REPLAY_LAST,
 ): MapMemoryProperty<ReactiveMutableMap<K, V>> {
-    return invoke { ReactiveMutableMap(strategy = strategy) }
+    return invoke { ReactiveMutableMap(initialMap, strategy) }
 }
 
 /**
@@ -33,8 +34,8 @@ public class ReactiveMutableMap<K, V : Any>(
     private val map = map.toMutableMap()
     private val subject: Subject<Map<K, V>> = when (strategy) {
         ReplayStrategy.NO_REPLAY -> PublishSubject.create()
-        ReplayStrategy.REPLAY_LAST -> BehaviorSubject.createDefault(map)
-        ReplayStrategy.REPLAY_ALL -> ReplaySubject.create()
+        ReplayStrategy.REPLAY_LAST -> BehaviorSubject.createDefault(map.toMap())
+        ReplayStrategy.REPLAY_ALL -> ReplaySubject.create<Map<K, V>>().apply { onNext(map.toMap()) }
     }
 
     // @formatter:off

--- a/mapmemory-rxjava3/api/mapmemory-rxjava3.api
+++ b/mapmemory-rxjava3/api/mapmemory-rxjava3.api
@@ -42,8 +42,8 @@ public final class com/redmadrobot/mapmemory/ReactiveMutableMapKt {
 	public static final fun getValuesObservable (Lcom/redmadrobot/mapmemory/ReactiveMutableMap;)Lio/reactivex/rxjava3/core/Observable;
 	public static final fun reactiveMap (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static synthetic fun reactiveMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 }
 
 public final class com/redmadrobot/mapmemory/RxAccessorsKt {

--- a/mapmemory-rxjava3/src/main/kotlin/ReactiveMutableMap.kt
+++ b/mapmemory-rxjava3/src/main/kotlin/ReactiveMutableMap.kt
@@ -8,13 +8,14 @@ import io.reactivex.rxjava3.subjects.Subject
 
 /**
  * Creates a delegate for dealing with [ReactiveMutableMap] stored in [MapMemory].
- * The delegate returns (and stores) empty `ReactiveMap` with specified [strategy]
- * if there is no corresponding value in memory.
+ * The delegate returns (and stores) `ReactiveMutableMap` with [initialMap] inside and specified
+ * [strategy] if there is no corresponding value in memory.
  */
 public fun <K, V : Any> MapMemory.reactiveMutableMap(
+    initialMap: Map<K, V> = emptyMap(),
     strategy: ReactiveMutableMap.ReplayStrategy = ReactiveMutableMap.ReplayStrategy.REPLAY_LAST,
 ): MapMemoryProperty<ReactiveMutableMap<K, V>> {
-    return invoke { ReactiveMutableMap(strategy = strategy) }
+    return invoke { ReactiveMutableMap(initialMap, strategy) }
 }
 
 /**
@@ -33,8 +34,8 @@ public class ReactiveMutableMap<K, V : Any>(
     private val map = map.toMutableMap()
     private val subject: Subject<Map<K, V>> = when (strategy) {
         ReplayStrategy.NO_REPLAY -> PublishSubject.create()
-        ReplayStrategy.REPLAY_LAST -> BehaviorSubject.createDefault(map)
-        ReplayStrategy.REPLAY_ALL -> ReplaySubject.create()
+        ReplayStrategy.REPLAY_LAST -> BehaviorSubject.createDefault(map.toMap())
+        ReplayStrategy.REPLAY_ALL -> ReplaySubject.create<Map<K, V>>().apply { onNext(map.toMap()) }
     }
 
     // @formatter:off


### PR DESCRIPTION
- Added parameter `initialMap` to `MapMemory.reactiveMutableMap()` extension
- Fixes #15