### PR TITLE
Reusable properties support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 ## [Unreleased]
 
+### Reusable properties
+
+Reusable properties introduced to address the problem described in issue #14
+
+Reusable properties survive `MapMemory.clear()` call. It will not be removed from cache, but will be cleared instead. Reusable properties are especially useful for reactive types like `Flow`. You don't need to resubscribe to flow after MapMemory was cleared.
+
+```kotlin
+val flow by memory.sharedFlow<Int>()
+
+// Subscribe to flow
+flow.onEach(::println).launchIn(coroutineScope)
+// And then clear MapMemory
+memory.crear()
+
+// Emitted value will be printed because the flow
+// is the same as before memory clear
+flow.emit(1)
+```
+
+You can create reusable property using operator `invoke` with `clear` lambda:
+
+```kotlin
+class Counter {
+    fun reset() = { /*...*/ }
+}
+
+val counter: Counter by memory(clear = { it.reset() }) { Counter() }
+```
+
+Many of default accessors are already turned into reusable: `mutableList`, `mutableMap`, `reactiveMutableMap`, `stateFlow`, `sharedFlow`, `behaviorSubject`, `publishSubject`.
+
 ### Changes
 
 - Added parameter `initialMap` to `MapMemory.reactiveMutableMap()` extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Changes
 
 - Added parameter `initialMap` to `MapMemory.reactiveMutableMap()` extension
+- :warning: **mapmemory-rxjava:** `ReplayStrategy` was removed. Please let us know if this change affected
+  you: https://github.com/RedMadRobot/mapmemory/discussions/20
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Simple in-memory cache conception built on `Map`.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Installation](#installation)
 - [Conception](#conception)
 - [Usage](#usage)
   - [Collections](#collections)
+  - [Reusable properties](#reusable-properties)
   - [Scoped and Shared values](#scoped-and-shared-values)
   - [Reactive Style](#reactive-style)
 - [Advanced usage](#advanced-usage)
-  - [Memory Lifetime](#memory-lifetime)
+  - [MapMemory Lifetime](#mapmemory-lifetime)
   - [Testing](#testing)
 - [Migration Guide](#migration-guide)
   - [Upgrading from v1.1](#upgrading-from-v11)
@@ -131,6 +131,25 @@ Accessors `mutableList` and `mutableMap` use concurrent collections under the ho
 | `mutableList()` | Empty mutable list | Store values in list  |
 
 Feel free to create your accessors if needed.
+
+### Reusable properties
+
+If you want to keep the same value on [MapMemory.clear] and clear the value instead of removing, you can create reusable property. Such properties use the given `clear` lambda to clear the current value.
+
+```kotlin
+class Counter {
+    fun reset() { /*...*/
+    }
+}
+
+val counter: Counter by memory(clear = { it.reset() }) { Counter() }
+```
+
+Reusable properties are especially useful for reactive types like `Flow` because you don't need to re-subscribe to flow after MapMemory was cleared.
+
+> **Info**  
+> Many of default accessors are already return reusable properties.
+> See accessor's description to check if it returns reusable property.
 
 ### Scoped and Shared values
 

--- a/mapmemory-coroutines/src/main/kotlin/CoroutinesAccessors.kt
+++ b/mapmemory-coroutines/src/main/kotlin/CoroutinesAccessors.kt
@@ -1,5 +1,6 @@
 package com.redmadrobot.mapmemory
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -7,19 +8,26 @@ import kotlinx.coroutines.flow.MutableStateFlow
 /**
  * Creates a delegate for dealing with [MutableStateFlow] stored in [MapMemory].
  * The delegate returns (and stores) new `MutableStateFlow` if there is no corresponding value in `MapMemory`.
+ *
+ * The property is _reusable_.
  */
 public fun <T> MapMemory.stateFlow(initialValue: T): MapMemoryProperty<MutableStateFlow<T>> {
-    return invoke { MutableStateFlow(initialValue) }
+    return invoke(clear = { it.value = initialValue }) { MutableStateFlow(initialValue) }
 }
 
 /**
  * Creates a delegate for dealing with [MutableSharedFlow] stored in [MapMemory].
  * The delegate returns (and stores) new `MutableSharedFlow` if there is no corresponding value in `MapMemory`.
+ *
+ * The property is _reusable_.
  */
 public fun <T> MapMemory.sharedFlow(
     replay: Int = 0,
     extraBufferCapacity: Int = 0,
     onBufferOverflow: BufferOverflow = BufferOverflow.SUSPEND,
 ): MapMemoryProperty<MutableSharedFlow<T>> {
-    return invoke { MutableSharedFlow(replay, extraBufferCapacity, onBufferOverflow) }
+    @OptIn(ExperimentalCoroutinesApi::class)
+    return invoke(clear = { it.resetReplayCache() }) {
+        MutableSharedFlow(replay, extraBufferCapacity, onBufferOverflow)
+    }
 }

--- a/mapmemory-coroutines/src/main/kotlin/ReactiveMutableMap.kt
+++ b/mapmemory-coroutines/src/main/kotlin/ReactiveMutableMap.kt
@@ -7,11 +7,13 @@ import kotlinx.coroutines.flow.*
  * Creates a delegate for dealing with [ReactiveMutableMap] stored in [MapMemory].
  * The delegate returns (and stores) `ReactiveMutableMap` with [initialMap] inside
  * if there is no corresponding value in `MapMemory`.
+ *
+ * The property is _reusable_.
  */
 public fun <K, V> MapMemory.reactiveMutableMap(
     initialMap: Map<K, V> = emptyMap(),
 ): MapMemoryProperty<ReactiveMutableMap<K, V>> {
-    return invoke { ReactiveMutableMap(initialMap) }
+    return invoke(clear = { it.replaceAll(initialMap) }) { ReactiveMutableMap(initialMap) }
 }
 
 /**
@@ -150,5 +152,5 @@ public typealias ReactiveMap<T> = ReactiveMutableMap<String, T>
 )
 @Suppress("Deprecation")
 public fun <T> MapMemory.reactiveMap(): MapMemoryProperty<ReactiveMap<T>> {
-    return invoke { ReactiveMap() }
+    return invoke(clear = { it.clear() }) { ReactiveMap() }
 }

--- a/mapmemory-coroutines/src/test/kotlin/CoroutinesAccessorsTest.kt
+++ b/mapmemory-coroutines/src/test/kotlin/CoroutinesAccessorsTest.kt
@@ -1,0 +1,42 @@
+package com.redmadrobot.mapmemory
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+internal class CoroutinesAccessorsTest {
+
+    private val memory = MapMemory()
+
+    @Test
+    fun `when cleared memory containing StateFlow - should keep the same flow and emit default value`() {
+        val flow by memory.stateFlow(0)
+
+        // Keep the original reference to the StateFlow
+        val originalFlow = flow
+        originalFlow.value = 1
+
+        memory.clear()
+
+        flow shouldBe originalFlow
+        originalFlow.value shouldBe 0
+    }
+
+    @Test
+    fun `when cleared memory containing SharedFlow - should keep the same flow and clear replay cache`() {
+        val flow by memory.sharedFlow<Int>(replay = 1)
+
+        // Keep the original reference to the StateFlow
+        val originalFlow = flow
+
+        // Fill replay cache
+        flow.tryEmit(1)
+        flow.replayCache shouldContainExactly listOf(1)
+
+        memory.clear()
+
+        flow shouldBe originalFlow
+        flow.replayCache.shouldBeEmpty()
+    }
+}

--- a/mapmemory-coroutines/src/test/kotlin/ReactiveMutableMapTest.kt
+++ b/mapmemory-coroutines/src/test/kotlin/ReactiveMutableMapTest.kt
@@ -3,6 +3,7 @@
 package com.redmadrobot.mapmemory
 
 import app.cash.turbine.test
+import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -21,5 +22,21 @@ class ReactiveMutableMapTest {
         map.flow.test {
             awaitItem() shouldBe initialMap
         }
+    }
+
+    @Test
+    fun `when cleared memory containing reactive map - should keep the same map and set default value`() {
+        val initialMap = mapOf("initial" to 42)
+
+        val map by memory.reactiveMutableMap(initialMap)
+
+        // Keep the original reference to the map
+        val originalMap = map
+        map["some_value"] = 1
+
+        memory.clear()
+
+        map shouldBe originalMap
+        map shouldContainExactly initialMap
     }
 }

--- a/mapmemory-rxjava2/api/mapmemory-rxjava2.api
+++ b/mapmemory-rxjava2/api/mapmemory-rxjava2.api
@@ -1,5 +1,7 @@
 public final class com/redmadrobot/mapmemory/ReactiveMutableMap : java/util/Map, kotlin/jvm/internal/markers/KMutableMap {
 	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/Map;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)V
 	public synthetic fun <init> (Ljava/util/Map;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun change (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
@@ -42,8 +44,9 @@ public final class com/redmadrobot/mapmemory/ReactiveMutableMapKt {
 	public static final fun getValuesObservable (Lcom/redmadrobot/mapmemory/ReactiveMutableMap;)Lio/reactivex/Observable;
 	public static final fun reactiveMap (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static synthetic fun reactiveMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 }
 
 public final class com/redmadrobot/mapmemory/RxAccessorsKt {

--- a/mapmemory-rxjava2/build.gradle.kts
+++ b/mapmemory-rxjava2/build.gradle.kts
@@ -8,4 +8,6 @@ description = "RxJava 2 accessors for MapMemory"
 dependencies {
     api(projects.mapmemory)
     api(libs.rxjava2)
+
+    testImplementation(libs.bundles.test)
 }

--- a/mapmemory-rxjava2/src/main/kotlin/RxAccessors.kt
+++ b/mapmemory-rxjava2/src/main/kotlin/RxAccessors.kt
@@ -1,26 +1,28 @@
-// Public API
-@file:Suppress("unused")
-
 package com.redmadrobot.mapmemory
 
 import io.reactivex.Maybe
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
+import io.reactivex.subjects.clear
 
 /**
  * Creates a delegate for dealing with [BehaviorSubject] stored in [MapMemory].
  * The delegate returns (and stores) new subject if there is no corresponding value in `MapMemory`.
+ *
+ * The property is _reusable_.
  */
 public fun <T : Any> MapMemory.behaviorSubject(): MapMemoryProperty<BehaviorSubject<T>> {
-    return invoke { BehaviorSubject.create() }
+    return invoke(clear = { it.clear() }) { BehaviorSubject.create() }
 }
 
 /**
  * Creates a delegate for dealing with [PublishSubject] stored in [MapMemory].
  * The delegate returns (and stores) new subject if there is no corresponding value in `MapMemory`.
+ *
+ * The property is _reusable_.
  */
 public fun <T : Any> MapMemory.publishSubject(): MapMemoryProperty<PublishSubject<T>> {
-    return invoke { PublishSubject.create() }
+    return invoke(clear = { /* no-op */ }) { PublishSubject.create() }
 }
 
 /**

--- a/mapmemory-rxjava2/src/main/kotlin/internal/SubjectsVisibilityHack.kt
+++ b/mapmemory-rxjava2/src/main/kotlin/internal/SubjectsVisibilityHack.kt
@@ -1,0 +1,7 @@
+@file:Suppress("PackageDirectoryMismatch")
+
+package io.reactivex.subjects
+
+internal fun BehaviorSubject<*>.clear() {
+    setCurrent(null)
+}

--- a/mapmemory-rxjava2/src/test/kotlin/ReactiveMutableMapTest.kt
+++ b/mapmemory-rxjava2/src/test/kotlin/ReactiveMutableMapTest.kt
@@ -1,0 +1,37 @@
+package com.redmadrobot.mapmemory
+
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class ReactiveMutableMapTest {
+
+    private val memory = MapMemory()
+
+    @Test
+    fun `when map initialized - should emit initial value to observable first`() {
+        val initialMap = mapOf("initial" to 42)
+
+        val map by memory.reactiveMutableMap(initialMap)
+
+        map.observable.test()
+            .assertValue(initialMap)
+            .dispose()
+    }
+
+    @Test
+    fun `when cleared memory containing reactive map - should keep the same map and set default value`() {
+        val initialMap = mapOf("initial" to 42)
+
+        val map by memory.reactiveMutableMap(initialMap)
+
+        // Keep the original reference to the map
+        val originalMap = map
+        map["some_value"] = 1
+
+        memory.clear()
+
+        map shouldBe originalMap
+        map shouldContainExactly initialMap
+    }
+}

--- a/mapmemory-rxjava2/src/test/kotlin/RxAccessorsTest.kt
+++ b/mapmemory-rxjava2/src/test/kotlin/RxAccessorsTest.kt
@@ -1,0 +1,41 @@
+package com.redmadrobot.mapmemory
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+internal class RxAccessorsTest {
+
+    private val memory = MapMemory()
+
+    @Test
+    fun `when cleared memory containing BehaviorSubject - should keep the same subject and clear it`() {
+        val subject by memory.behaviorSubject<Int>()
+
+        // Keep the original reference to the subject
+        val originalSubject = subject
+        originalSubject.onNext(1)
+
+        memory.clear()
+
+        subject shouldBe originalSubject
+        originalSubject.test()
+            .assertEmpty()
+            .dispose()
+    }
+
+    @Test
+    fun `when cleared memory containing PublishSubject - should keep the same subject`() {
+        val subject by memory.publishSubject<Int>()
+
+        // Keep the original reference to the subject
+        val originalSubject = subject
+        originalSubject.onNext(1)
+
+        memory.clear()
+
+        subject shouldBe originalSubject
+        originalSubject.test()
+            .assertEmpty()
+            .dispose()
+    }
+}

--- a/mapmemory-rxjava3/api/mapmemory-rxjava3.api
+++ b/mapmemory-rxjava3/api/mapmemory-rxjava3.api
@@ -1,5 +1,7 @@
 public final class com/redmadrobot/mapmemory/ReactiveMutableMap : java/util/Map, kotlin/jvm/internal/markers/KMutableMap {
 	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/Map;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)V
 	public synthetic fun <init> (Ljava/util/Map;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun change (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
@@ -42,8 +44,9 @@ public final class com/redmadrobot/mapmemory/ReactiveMutableMapKt {
 	public static final fun getValuesObservable (Lcom/redmadrobot/mapmemory/ReactiveMutableMap;)Lio/reactivex/rxjava3/core/Observable;
 	public static final fun reactiveMap (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static synthetic fun reactiveMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 }
 
 public final class com/redmadrobot/mapmemory/RxAccessorsKt {

--- a/mapmemory-rxjava3/build.gradle.kts
+++ b/mapmemory-rxjava3/build.gradle.kts
@@ -8,4 +8,6 @@ description = "RxJava 3 accessors for MapMemory"
 dependencies {
     api(projects.mapmemory)
     api(libs.rxjava3)
+
+    testImplementation(libs.bundles.test)
 }

--- a/mapmemory-rxjava3/src/main/kotlin/ReactiveMutableMap.kt
+++ b/mapmemory-rxjava3/src/main/kotlin/ReactiveMutableMap.kt
@@ -2,20 +2,18 @@ package com.redmadrobot.mapmemory
 
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.subjects.BehaviorSubject
-import io.reactivex.rxjava3.subjects.PublishSubject
-import io.reactivex.rxjava3.subjects.ReplaySubject
-import io.reactivex.rxjava3.subjects.Subject
 
 /**
  * Creates a delegate for dealing with [ReactiveMutableMap] stored in [MapMemory].
- * The delegate returns (and stores) `ReactiveMutableMap` with [initialMap] inside and specified
- * [strategy] if there is no corresponding value in `MapMemory`.
+ * The delegate returns (and stores) `ReactiveMutableMap` with [initialMap] inside
+ * if there is no corresponding value in `MapMemory`.
+ *
+ * The property is _reusable_.
  */
 public fun <K, V : Any> MapMemory.reactiveMutableMap(
     initialMap: Map<K, V> = emptyMap(),
-    strategy: ReactiveMutableMap.ReplayStrategy = ReactiveMutableMap.ReplayStrategy.REPLAY_LAST,
 ): MapMemoryProperty<ReactiveMutableMap<K, V>> {
-    return invoke { ReactiveMutableMap(initialMap, strategy) }
+    return invoke(clear = { it.replaceAll(initialMap) }) { ReactiveMutableMap(initialMap) }
 }
 
 /**
@@ -28,15 +26,20 @@ public fun <K, V : Any> MapMemory.reactiveMutableMap(
 @Suppress("TooManyFunctions")
 public class ReactiveMutableMap<K, V : Any>(
     map: Map<K, V> = emptyMap(),
-    strategy: ReplayStrategy = ReplayStrategy.REPLAY_LAST,
 ) : MutableMap<K, V> {
 
     private val map = map.toMutableMap()
-    private val subject: Subject<Map<K, V>> = when (strategy) {
-        ReplayStrategy.NO_REPLAY -> PublishSubject.create()
-        ReplayStrategy.REPLAY_LAST -> BehaviorSubject.createDefault(map.toMap())
-        ReplayStrategy.REPLAY_ALL -> ReplaySubject.create<Map<K, V>>().apply { onNext(map.toMap()) }
-    }
+    private val subject = BehaviorSubject.createDefault(map.toMap())
+
+    @Deprecated(
+        "Strategy is deprecated, REPLAY_LAST always used",
+        ReplaceWith("ReactiveMutableMap<K, V>(map)"),
+        DeprecationLevel.ERROR,
+    )
+    public constructor(
+        map: Map<K, V> = emptyMap(),
+        @Suppress("UNUSED_PARAMETER", "DEPRECATION") strategy: ReplayStrategy,
+    ) : this(map)
 
     // @formatter:off
     @Synchronized override fun equals(other: Any?): Boolean = map == other
@@ -74,7 +77,7 @@ public class ReactiveMutableMap<K, V : Any>(
      */
     @Deprecated(
         message = "Replaced with getValueObservable",
-        replaceWith = ReplaceWith("getValueObservable(key)")
+        replaceWith = ReplaceWith("getValueObservable(key)"),
     )
     public fun getStream(key: K): Observable<V> {
         return subject.flatMap { map ->
@@ -110,7 +113,12 @@ public class ReactiveMutableMap<K, V : Any>(
         }
     }
 
-    /** Values reply strategy. */
+    /**
+     * NOTE: All replay strategies was removed in favor of REPLAY_LAST behavior.
+     * If this change affects you, please provide your use-case here:
+     *  https://github.com/RedMadRobot/mapmemory/discussions/20
+     */
+    @Deprecated("All strategies except REPLAY_LAST are removed")
     public enum class ReplayStrategy {
         /** Subscriber will not receive values emitted before subscription. */
         NO_REPLAY,
@@ -153,12 +161,27 @@ public typealias ReactiveMap<T> = ReactiveMutableMap<String, T>
 
 /** @see reactiveMutableMap */
 @Deprecated(
-    message = "Replaced with reactiveMutableMap",
-    replaceWith = ReplaceWith("reactiveMutableMap<String, T>(strategy)"),
+    "Replaced with reactiveMutableMap",
+    ReplaceWith("reactiveMutableMap<String, T>()"),
 )
-@Suppress("Deprecation")
+@Suppress("Deprecation", "UNUSED_PARAMETER")
 public fun <T : Any> MapMemory.reactiveMap(
     strategy: ReactiveMutableMap.ReplayStrategy = ReactiveMutableMap.ReplayStrategy.REPLAY_LAST,
 ): MapMemoryProperty<ReactiveMap<T>> {
-    return invoke { ReactiveMap(strategy = strategy) }
+    return invoke { ReactiveMap() }
+}
+
+/**
+ * @see reactiveMutableMap
+ */
+@Deprecated(
+    "Use reactiveMutableMap without strategy, current behavior equals to REPLAY_LAST strategy",
+    ReplaceWith("reactiveMutableMap<K, V>()"),
+    DeprecationLevel.ERROR,
+)
+@Suppress("UnusedReceiverParameter", "UNUSED_PARAMETER", "DEPRECATION")
+public fun <K, V : Any> MapMemory.reactiveMutableMap(
+    strategy: ReactiveMutableMap.ReplayStrategy,
+): MapMemoryProperty<ReactiveMutableMap<K, V>> {
+    error("Should not be called")
 }

--- a/mapmemory-rxjava3/src/main/kotlin/RxAccessors.kt
+++ b/mapmemory-rxjava3/src/main/kotlin/RxAccessors.kt
@@ -1,26 +1,28 @@
-// Public API
-@file:Suppress("unused")
-
 package com.redmadrobot.mapmemory
 
 import io.reactivex.rxjava3.core.Maybe
 import io.reactivex.rxjava3.subjects.BehaviorSubject
 import io.reactivex.rxjava3.subjects.PublishSubject
+import io.reactivex.rxjava3.subjects.clear
 
 /**
  * Creates a delegate for dealing with [BehaviorSubject] stored in [MapMemory].
  * The delegate returns (and stores) new subject if there is no corresponding value in `MapMemory`.
+ *
+ * The property is _reusable_.
  */
 public fun <T : Any> MapMemory.behaviorSubject(): MapMemoryProperty<BehaviorSubject<T>> {
-    return invoke { BehaviorSubject.create() }
+    return invoke(clear = { it.clear() }) { BehaviorSubject.create() }
 }
 
 /**
  * Creates a delegate for dealing with [PublishSubject] stored in [MapMemory].
  * The delegate returns (and stores) new subject if there is no corresponding value in `MapMemory`.
+ *
+ * The property is _reusable_.
  */
 public fun <T : Any> MapMemory.publishSubject(): MapMemoryProperty<PublishSubject<T>> {
-    return invoke { PublishSubject.create() }
+    return invoke(clear = { /* no-op */ }) { PublishSubject.create() }
 }
 
 /**

--- a/mapmemory-rxjava3/src/main/kotlin/internal/SubjectsVisibilityHack.kt
+++ b/mapmemory-rxjava3/src/main/kotlin/internal/SubjectsVisibilityHack.kt
@@ -1,0 +1,7 @@
+@file:Suppress("PackageDirectoryMismatch")
+
+package io.reactivex.rxjava3.subjects
+
+internal fun BehaviorSubject<*>.clear() {
+    setCurrent(null)
+}

--- a/mapmemory-rxjava3/src/test/kotlin/ReactiveMutableMapTest.kt
+++ b/mapmemory-rxjava3/src/test/kotlin/ReactiveMutableMapTest.kt
@@ -1,0 +1,37 @@
+package com.redmadrobot.mapmemory
+
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class ReactiveMutableMapTest {
+
+    private val memory = MapMemory()
+
+    @Test
+    fun `when map initialized - should emit initial value to observable first`() {
+        val initialMap = mapOf("initial" to 42)
+
+        val map by memory.reactiveMutableMap(initialMap)
+
+        map.observable.test()
+            .assertValue(initialMap)
+            .dispose()
+    }
+
+    @Test
+    fun `when cleared memory containing reactive map - should keep the same map and set default value`() {
+        val initialMap = mapOf("initial" to 42)
+
+        val map by memory.reactiveMutableMap(initialMap)
+
+        // Keep the original reference to the map
+        val originalMap = map
+        map["some_value"] = 1
+
+        memory.clear()
+
+        map shouldBe originalMap
+        map shouldContainExactly initialMap
+    }
+}

--- a/mapmemory-rxjava3/src/test/kotlin/RxAccessorsTest.kt
+++ b/mapmemory-rxjava3/src/test/kotlin/RxAccessorsTest.kt
@@ -1,0 +1,41 @@
+package com.redmadrobot.mapmemory
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+internal class RxAccessorsTest {
+
+    private val memory = MapMemory()
+
+    @Test
+    fun `when cleared memory containing BehaviorSubject - should keep the same subject and clear it`() {
+        val subject by memory.behaviorSubject<Int>()
+
+        // Keep the original reference to the subject
+        val originalSubject = subject
+        originalSubject.onNext(1)
+
+        memory.clear()
+
+        subject shouldBe originalSubject
+        originalSubject.test()
+            .assertEmpty()
+            .dispose()
+    }
+
+    @Test
+    fun `when cleared memory containing PublishSubject - should keep the same subject`() {
+        val subject by memory.publishSubject<Int>()
+
+        // Keep the original reference to the subject
+        val originalSubject = subject
+        originalSubject.onNext(1)
+
+        memory.clear()
+
+        subject shouldBe originalSubject
+        originalSubject.test()
+            .assertEmpty()
+            .dispose()
+    }
+}

--- a/mapmemory/api/mapmemory.api
+++ b/mapmemory/api/mapmemory.api
@@ -18,10 +18,12 @@ public class com/redmadrobot/mapmemory/MapMemory : java/util/Map, kotlin/jvm/int
 	public synthetic fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun put (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun putAll (Ljava/util/Map;)V
+	public final fun putReusable (Ljava/lang/String;Lcom/redmadrobot/mapmemory/internal/ClearableValue;)V
 	public final fun remove (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun remove (Ljava/lang/String;)Ljava/lang/Object;
 	public final fun setValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
 	public final fun size ()I
+	public final fun updateReusable (Ljava/lang/String;Ljava/lang/Object;)V
 	public final fun values ()Ljava/util/Collection;
 	public final fun withDefault (Lkotlin/jvm/functions/Function1;)Ljava/util/Map;
 }

--- a/mapmemory/src/main/kotlin/MapMemory.kt
+++ b/mapmemory/src/main/kotlin/MapMemory.kt
@@ -34,6 +34,25 @@ import kotlin.reflect.KProperty
  * var counter: Int by memory { 0 }
  * ```
  *
+ * ### Reusable properties
+ *
+ * If you want to keep the same value on [MapMemory.clear] and clear the value
+ * instead of removing, you can create reusable property. Such properties use
+ * the given `clear` lambda to clear the current value.
+ * ```
+ * class Counter {
+ *     fun reset() { /*...*/ }
+ * }
+ *
+ * val counter: Counter by memory(clear = { it.reset() }) { Counter() }
+ * ```
+ *
+ * Reusable properties are especially useful for reactive types like `Flow`
+ * because you don't need to re-subscribe to flow after MapMemory was cleared.
+ *
+ * Many of default accessors are already return reusable properties.
+ * See accessor's description to check if it returns reusable property.
+ *
  * ### Scoped and shared values
  *
  * Delegate accesses `MapMemory` values by key retrieved from property name.
@@ -73,7 +92,7 @@ public open class MapMemory private constructor(
      * the current value and reuse it instead of removing.
      * ```
      * class Counter {
-     *     fun reset()
+     *     fun reset() { /*...*/ }
      * }
      *
      * val counter: Counter by memory(clear = { it.reset() }) { Counter() }

--- a/mapmemory/src/main/kotlin/MemoryAccessors.kt
+++ b/mapmemory/src/main/kotlin/MemoryAccessors.kt
@@ -17,6 +17,8 @@ public fun <K, V> MapMemory.map(): MapMemoryProperty<Map<K, V>> {
  * Creates a delegate for dealing with [MutableMap] stored in [MapMemory].
  * The delegate returns (and stores) empty map if there is no corresponding value in `MapMemory`.
  * Uses [ConcurrentHashMap] implementation.
+ *
+ * The property is _reusable_.
  */
 public fun <K, V> MapMemory.mutableMap(): MapMemoryProperty<MutableMap<K, V>> {
     return invoke(clear = { it.clear() }) { ConcurrentHashMap<K, V>() }
@@ -34,6 +36,8 @@ public fun <T> MapMemory.list(): MapMemoryProperty<List<T>> {
  * Creates a delegate for dealing with [MutableList] stored in [MapMemory].
  * The delegate returns (and stores) empty list if there is no corresponding value in `MapMemory`.
  * Uses synchronized list implementation.
+ *
+ * The property is _reusable_.
  */
 public fun <T> MapMemory.mutableList(): MapMemoryProperty<MutableList<T>> {
     return invoke(clear = { it.clear() }) { Collections.synchronizedList(mutableListOf()) }

--- a/mapmemory/src/main/kotlin/MemoryAccessors.kt
+++ b/mapmemory/src/main/kotlin/MemoryAccessors.kt
@@ -19,7 +19,7 @@ public fun <K, V> MapMemory.map(): MapMemoryProperty<Map<K, V>> {
  * Uses [ConcurrentHashMap] implementation.
  */
 public fun <K, V> MapMemory.mutableMap(): MapMemoryProperty<MutableMap<K, V>> {
-    return invoke { ConcurrentHashMap<K, V>() }
+    return invoke(clear = { it.clear() }) { ConcurrentHashMap<K, V>() }
 }
 
 /**
@@ -36,7 +36,7 @@ public fun <T> MapMemory.list(): MapMemoryProperty<List<T>> {
  * Uses synchronized list implementation.
  */
 public fun <T> MapMemory.mutableList(): MapMemoryProperty<MutableList<T>> {
-    return invoke { Collections.synchronizedList(mutableListOf()) }
+    return invoke(clear = { it.clear() }) { Collections.synchronizedList(mutableListOf()) }
 }
 
 /**

--- a/mapmemory/src/main/kotlin/internal/ReusableProperty.kt
+++ b/mapmemory/src/main/kotlin/internal/ReusableProperty.kt
@@ -1,0 +1,32 @@
+package com.redmadrobot.mapmemory.internal
+
+import com.redmadrobot.mapmemory.MapMemory
+import com.redmadrobot.mapmemory.MapMemoryProperty
+
+@PublishedApi
+internal inline fun <reified V : Any> MapMemory.reusableGetOrPutProperty(
+    noinline clear: (V) -> Unit,
+    crossinline defaultValue: () -> V,
+): MapMemoryProperty<V> = object : MapMemoryProperty<V>() {
+    override fun getValue(key: String): V {
+        return getOrPut(key) {
+            defaultValue().also { value ->
+                val clearableValue = ClearableValue(value, clear)
+                putReusable(key, clearableValue)
+            }
+        } as V
+    }
+
+    override fun setValue(key: String, value: V) {
+        putNotNull(key, value)
+        updateReusable(key, value)
+    }
+}
+
+@PublishedApi
+internal data class ClearableValue<V : Any>(
+    val value: V,
+    val clear: (V) -> Unit,
+) {
+    fun getCleared(): V = value.apply(clear)
+}

--- a/mapmemory/src/test/kotlin/ReusablePropertiesTest.kt
+++ b/mapmemory/src/test/kotlin/ReusablePropertiesTest.kt
@@ -1,5 +1,6 @@
 package com.redmadrobot.mapmemory
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.shouldBe
@@ -37,5 +38,26 @@ internal class ReusablePropertiesTest {
 
         map shouldBe originalMap
         map shouldContainExactly mapOf("Answer" to 42)
+    }
+
+    @Test
+    fun `when cleared memory containing mutable list - and the list was replaced before - should keep the last assigned list and clear it`() {
+        var list by memory.mutableList<Int>()
+
+        // Keep the reference to the original list
+        val originalList = list
+        originalList += 0
+
+        // Replace the list in MapMemory
+        val newList = mutableListOf(1)
+        list = newList
+
+        memory.clear()
+        newList += 42
+
+        assertSoftly {
+            originalList.shouldContainExactly(0)
+            newList.shouldContainExactly(42)
+        }
     }
 }

--- a/mapmemory/src/test/kotlin/ReusablePropertiesTest.kt
+++ b/mapmemory/src/test/kotlin/ReusablePropertiesTest.kt
@@ -1,0 +1,41 @@
+package com.redmadrobot.mapmemory
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+internal class ReusablePropertiesTest {
+
+    private val memory = MapMemory()
+
+    @Test
+    fun `when cleared memory containing mutable list - should keep the list and clear it`() {
+        val list by memory.mutableList<Int>()
+
+        // Keep the reference to the original list
+        val originalList = list
+        list += 0
+
+        memory.clear()
+        list += 42
+
+        list shouldBe originalList
+        list.shouldContainExactly(42)
+    }
+
+    @Test
+    fun `when cleared memory containing mutable map - should keep the map and clear it`() {
+        val map by memory.mutableMap<String, Int>()
+
+        // Keep the reference to the original map
+        val originalMap = map
+        map["Zero"] = 0
+
+        memory.clear()
+        map["Answer"] = 42
+
+        map shouldBe originalMap
+        map shouldContainExactly mapOf("Answer" to 42)
+    }
+}


### PR DESCRIPTION
Added support for reusable values. Currently, reusable values are `MutableMap`, `MutableList`, `StateFlow`, `SharedFlow`, `ReactiveMutableMap`

Closes #14, Opens #20

### TODO:

- [x] Adopt Rx accessors
- [x] Add changelog
- [x] Update readme
- [x] Add "reusable" mark to accessors' docs