### PR TITLE
Accessors default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,8 @@ Many of default accessors are already turned into reusable: `mutableList`, `muta
 
 ### Changes
 
-- Added parameter `initialMap` to `MapMemory.reactiveMutableMap()` extension
-- :warning: **mapmemory-rxjava:** `ReplayStrategy` was removed. Please let us know if this change affected
-  you: https://github.com/RedMadRobot/mapmemory/discussions/20
+- Added parameter `defaultValue` to most of reusable properties: `mutableList`, `mutableMap`, `reactiveMutableMap`, `behaviorSubject`.
+- :warning: **mapmemory-rxjava:** `ReplayStrategy` was removed. Please let us know if this change affected you: https://github.com/RedMadRobot/mapmemory/discussions/20
 
 ### Fixes
 

--- a/mapmemory-coroutines/api/mapmemory-coroutines.api
+++ b/mapmemory-coroutines/api/mapmemory-coroutines.api
@@ -40,7 +40,7 @@ public final class com/redmadrobot/mapmemory/ReactiveMutableMapKt {
 	public static final fun getValueFlow (Lcom/redmadrobot/mapmemory/ReactiveMutableMap;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun getValuesFlow (Lcom/redmadrobot/mapmemory/ReactiveMutableMap;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun reactiveMap (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Lkotlin/jvm/functions/Function0;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 }
 

--- a/mapmemory-coroutines/src/main/kotlin/ReactiveMutableMap.kt
+++ b/mapmemory-coroutines/src/main/kotlin/ReactiveMutableMap.kt
@@ -5,15 +5,15 @@ import kotlinx.coroutines.flow.*
 
 /**
  * Creates a delegate for dealing with [ReactiveMutableMap] stored in [MapMemory].
- * The delegate returns (and stores) `ReactiveMutableMap` with [initialMap] inside
+ * The delegate returns (and stores) `ReactiveMutableMap` with [defaultValue] inside
  * if there is no corresponding value in `MapMemory`.
  *
  * The property is _reusable_.
  */
 public fun <K, V> MapMemory.reactiveMutableMap(
-    initialMap: Map<K, V> = emptyMap(),
+    defaultValue: () -> Map<K, V> = ::emptyMap,
 ): MapMemoryProperty<ReactiveMutableMap<K, V>> {
-    return invoke(clear = { it.replaceAll(initialMap) }) { ReactiveMutableMap(initialMap) }
+    return invoke(clear = { it.replaceAll(defaultValue()) }) { ReactiveMutableMap(defaultValue()) }
 }
 
 /**

--- a/mapmemory-coroutines/src/test/kotlin/ReactiveMutableMapTest.kt
+++ b/mapmemory-coroutines/src/test/kotlin/ReactiveMutableMapTest.kt
@@ -17,7 +17,7 @@ class ReactiveMutableMapTest {
     fun `when map initialized - should emit initial value to flow first`() = runTest {
         val initialMap = mapOf("initial" to 42)
 
-        val map by memory.reactiveMutableMap(initialMap)
+        val map by memory.reactiveMutableMap { initialMap }
 
         map.flow.test {
             awaitItem() shouldBe initialMap
@@ -28,7 +28,7 @@ class ReactiveMutableMapTest {
     fun `when cleared memory containing reactive map - should keep the same map and set default value`() {
         val initialMap = mapOf("initial" to 42)
 
-        val map by memory.reactiveMutableMap(initialMap)
+        val map by memory.reactiveMutableMap { initialMap }
 
         // Keep the original reference to the map
         val originalMap = map

--- a/mapmemory-rxjava2/api/mapmemory-rxjava2.api
+++ b/mapmemory-rxjava2/api/mapmemory-rxjava2.api
@@ -45,12 +45,13 @@ public final class com/redmadrobot/mapmemory/ReactiveMutableMapKt {
 	public static final fun reactiveMap (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static synthetic fun reactiveMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Lkotlin/jvm/functions/Function0;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 }
 
 public final class com/redmadrobot/mapmemory/RxAccessorsKt {
 	public static final fun behaviorSubject (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun behaviorSubject (Lcom/redmadrobot/mapmemory/MapMemory;Lkotlin/jvm/functions/Function0;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static final fun maybe (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static final fun publishSubject (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 }

--- a/mapmemory-rxjava2/src/main/kotlin/ReactiveMutableMap.kt
+++ b/mapmemory-rxjava2/src/main/kotlin/ReactiveMutableMap.kt
@@ -5,15 +5,15 @@ import io.reactivex.subjects.BehaviorSubject
 
 /**
  * Creates a delegate for dealing with [ReactiveMutableMap] stored in [MapMemory].
- * The delegate returns (and stores) `ReactiveMutableMap` with [initialMap] inside
+ * The delegate returns (and stores) `ReactiveMutableMap` with [defaultValue] inside
  * if there is no corresponding value in `MapMemory`.
  *
  * The property is _reusable_.
  */
 public fun <K, V : Any> MapMemory.reactiveMutableMap(
-    initialMap: Map<K, V> = emptyMap(),
+    defaultValue: () -> Map<K, V> = ::emptyMap,
 ): MapMemoryProperty<ReactiveMutableMap<K, V>> {
-    return invoke(clear = { it.replaceAll(initialMap) }) { ReactiveMutableMap(initialMap) }
+    return invoke(clear = { it.replaceAll(defaultValue()) }) { ReactiveMutableMap(defaultValue()) }
 }
 
 /**

--- a/mapmemory-rxjava2/src/main/kotlin/RxAccessors.kt
+++ b/mapmemory-rxjava2/src/main/kotlin/RxAccessors.kt
@@ -16,6 +16,17 @@ public fun <T : Any> MapMemory.behaviorSubject(): MapMemoryProperty<BehaviorSubj
 }
 
 /**
+ * Creates a delegate for dealing with [BehaviorSubject] stored in [MapMemory].
+ * The delegate returns (and stores) new subject with [defaultValue] inside
+ * if there is no corresponding value in `MapMemory`.
+ *
+ * The property is _reusable_.
+ */
+public fun <T : Any> MapMemory.behaviorSubject(defaultValue: () -> T): MapMemoryProperty<BehaviorSubject<T>> {
+    return invoke(clear = { it.onNext(defaultValue()) }) { BehaviorSubject.createDefault(defaultValue()) }
+}
+
+/**
  * Creates a delegate for dealing with [PublishSubject] stored in [MapMemory].
  * The delegate returns (and stores) new subject if there is no corresponding value in `MapMemory`.
  *

--- a/mapmemory-rxjava2/src/test/kotlin/ReactiveMutableMapTest.kt
+++ b/mapmemory-rxjava2/src/test/kotlin/ReactiveMutableMapTest.kt
@@ -12,7 +12,7 @@ class ReactiveMutableMapTest {
     fun `when map initialized - should emit initial value to observable first`() {
         val initialMap = mapOf("initial" to 42)
 
-        val map by memory.reactiveMutableMap(initialMap)
+        val map by memory.reactiveMutableMap { initialMap }
 
         map.observable.test()
             .assertValue(initialMap)
@@ -23,7 +23,7 @@ class ReactiveMutableMapTest {
     fun `when cleared memory containing reactive map - should keep the same map and set default value`() {
         val initialMap = mapOf("initial" to 42)
 
-        val map by memory.reactiveMutableMap(initialMap)
+        val map by memory.reactiveMutableMap { initialMap }
 
         // Keep the original reference to the map
         val originalMap = map

--- a/mapmemory-rxjava2/src/test/kotlin/RxAccessorsTest.kt
+++ b/mapmemory-rxjava2/src/test/kotlin/RxAccessorsTest.kt
@@ -24,6 +24,22 @@ internal class RxAccessorsTest {
     }
 
     @Test
+    fun `when cleared memory containing BehaviorSubject - should keep the same subject and emit default value`() {
+        val subject by memory.behaviorSubject { 0 }
+
+        // Keep the original reference to the subject
+        val originalSubject = subject
+        subject.onNext(1)
+
+        memory.clear()
+
+        subject shouldBe originalSubject
+        subject.test()
+            .assertValue(0)
+            .dispose()
+    }
+
+    @Test
     fun `when cleared memory containing PublishSubject - should keep the same subject`() {
         val subject by memory.publishSubject<Int>()
 

--- a/mapmemory-rxjava3/api/mapmemory-rxjava3.api
+++ b/mapmemory-rxjava3/api/mapmemory-rxjava3.api
@@ -45,12 +45,13 @@ public final class com/redmadrobot/mapmemory/ReactiveMutableMapKt {
 	public static final fun reactiveMap (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static synthetic fun reactiveMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Lcom/redmadrobot/mapmemory/ReactiveMutableMap$ReplayStrategy;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Ljava/util/Map;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun reactiveMutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Lkotlin/jvm/functions/Function0;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static synthetic fun reactiveMutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 }
 
 public final class com/redmadrobot/mapmemory/RxAccessorsKt {
 	public static final fun behaviorSubject (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun behaviorSubject (Lcom/redmadrobot/mapmemory/MapMemory;Lkotlin/jvm/functions/Function0;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static final fun maybe (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static final fun publishSubject (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 }

--- a/mapmemory-rxjava3/src/main/kotlin/ReactiveMutableMap.kt
+++ b/mapmemory-rxjava3/src/main/kotlin/ReactiveMutableMap.kt
@@ -5,15 +5,15 @@ import io.reactivex.rxjava3.subjects.BehaviorSubject
 
 /**
  * Creates a delegate for dealing with [ReactiveMutableMap] stored in [MapMemory].
- * The delegate returns (and stores) `ReactiveMutableMap` with [initialMap] inside
+ * The delegate returns (and stores) `ReactiveMutableMap` with [defaultValue] inside
  * if there is no corresponding value in `MapMemory`.
  *
  * The property is _reusable_.
  */
 public fun <K, V : Any> MapMemory.reactiveMutableMap(
-    initialMap: Map<K, V> = emptyMap(),
+    defaultValue: () -> Map<K, V> = ::emptyMap,
 ): MapMemoryProperty<ReactiveMutableMap<K, V>> {
-    return invoke(clear = { it.replaceAll(initialMap) }) { ReactiveMutableMap(initialMap) }
+    return invoke(clear = { it.replaceAll(defaultValue()) }) { ReactiveMutableMap(defaultValue()) }
 }
 
 /**

--- a/mapmemory-rxjava3/src/main/kotlin/RxAccessors.kt
+++ b/mapmemory-rxjava3/src/main/kotlin/RxAccessors.kt
@@ -16,6 +16,17 @@ public fun <T : Any> MapMemory.behaviorSubject(): MapMemoryProperty<BehaviorSubj
 }
 
 /**
+ * Creates a delegate for dealing with [BehaviorSubject] stored in [MapMemory].
+ * The delegate returns (and stores) new subject with [defaultValue] inside
+ * if there is no corresponding value in `MapMemory`.
+ *
+ * The property is _reusable_.
+ */
+public fun <T : Any> MapMemory.behaviorSubject(defaultValue: () -> T): MapMemoryProperty<BehaviorSubject<T>> {
+    return invoke(clear = { it.onNext(defaultValue()) }) { BehaviorSubject.createDefault(defaultValue()) }
+}
+
+/**
  * Creates a delegate for dealing with [PublishSubject] stored in [MapMemory].
  * The delegate returns (and stores) new subject if there is no corresponding value in `MapMemory`.
  *

--- a/mapmemory-rxjava3/src/test/kotlin/ReactiveMutableMapTest.kt
+++ b/mapmemory-rxjava3/src/test/kotlin/ReactiveMutableMapTest.kt
@@ -12,7 +12,7 @@ class ReactiveMutableMapTest {
     fun `when map initialized - should emit initial value to observable first`() {
         val initialMap = mapOf("initial" to 42)
 
-        val map by memory.reactiveMutableMap(initialMap)
+        val map by memory.reactiveMutableMap { initialMap }
 
         map.observable.test()
             .assertValue(initialMap)
@@ -23,7 +23,7 @@ class ReactiveMutableMapTest {
     fun `when cleared memory containing reactive map - should keep the same map and set default value`() {
         val initialMap = mapOf("initial" to 42)
 
-        val map by memory.reactiveMutableMap(initialMap)
+        val map by memory.reactiveMutableMap { initialMap }
 
         // Keep the original reference to the map
         val originalMap = map

--- a/mapmemory-rxjava3/src/test/kotlin/RxAccessorsTest.kt
+++ b/mapmemory-rxjava3/src/test/kotlin/RxAccessorsTest.kt
@@ -24,6 +24,22 @@ internal class RxAccessorsTest {
     }
 
     @Test
+    fun `when cleared memory containing BehaviorSubject - should keep the same subject and emit default value`() {
+        val subject by memory.behaviorSubject { 0 }
+
+        // Keep the original reference to the subject
+        val originalSubject = subject
+        subject.onNext(1)
+
+        memory.clear()
+
+        subject shouldBe originalSubject
+        subject.test()
+            .assertValue(0)
+            .dispose()
+    }
+
+    @Test
     fun `when cleared memory containing PublishSubject - should keep the same subject`() {
         val subject by memory.publishSubject<Int>()
 

--- a/mapmemory/api/mapmemory.api
+++ b/mapmemory/api/mapmemory.api
@@ -40,8 +40,10 @@ public abstract class com/redmadrobot/mapmemory/MapMemoryProperty : kotlin/prope
 public final class com/redmadrobot/mapmemory/MemoryAccessorsKt {
 	public static final fun list (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 	public static final fun map (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static final fun mutableList (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
-	public static final fun mutableMap (Lcom/redmadrobot/mapmemory/MapMemory;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun mutableList (Lcom/redmadrobot/mapmemory/MapMemory;Lkotlin/jvm/functions/Function0;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static synthetic fun mutableList$default (Lcom/redmadrobot/mapmemory/MapMemory;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static final fun mutableMap (Lcom/redmadrobot/mapmemory/MapMemory;Lkotlin/jvm/functions/Function0;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
+	public static synthetic fun mutableMap$default (Lcom/redmadrobot/mapmemory/MapMemory;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/redmadrobot/mapmemory/MapMemoryProperty;
 }
 
 public final class com/redmadrobot/mapmemory/SharedMapMemoryPropertyKt {

--- a/mapmemory/src/main/kotlin/MemoryAccessors.kt
+++ b/mapmemory/src/main/kotlin/MemoryAccessors.kt
@@ -15,13 +15,24 @@ public fun <K, V> MapMemory.map(): MapMemoryProperty<Map<K, V>> {
 
 /**
  * Creates a delegate for dealing with [MutableMap] stored in [MapMemory].
- * The delegate returns (and stores) empty map if there is no corresponding value in `MapMemory`.
+ * The delegate returns (and stores) map with [defaultValue] inside
+ * if there is no corresponding value in `MapMemory`.
  * Uses [ConcurrentHashMap] implementation.
  *
  * The property is _reusable_.
  */
-public fun <K, V> MapMemory.mutableMap(): MapMemoryProperty<MutableMap<K, V>> {
-    return invoke(clear = { it.clear() }) { ConcurrentHashMap<K, V>() }
+public fun <K, V> MapMemory.mutableMap(
+    defaultValue: () -> Map<K, V> = ::emptyMap,
+): MapMemoryProperty<MutableMap<K, V>> {
+    return invoke(
+        clear = { map ->
+            synchronized(map) {
+                map.clear()
+                map.putAll(defaultValue())
+            }
+        },
+        defaultValue = { ConcurrentHashMap<K, V>(defaultValue()) },
+    )
 }
 
 /**
@@ -34,13 +45,22 @@ public fun <T> MapMemory.list(): MapMemoryProperty<List<T>> {
 
 /**
  * Creates a delegate for dealing with [MutableList] stored in [MapMemory].
- * The delegate returns (and stores) empty list if there is no corresponding value in `MapMemory`.
- * Uses synchronized list implementation.
+ * The delegate returns (and stores) list with [defaultValue] inside
+ * if there is no corresponding value in `MapMemory`.
+ * Uses synchronized `ArrayList` implementation.
  *
  * The property is _reusable_.
  */
-public fun <T> MapMemory.mutableList(): MapMemoryProperty<MutableList<T>> {
-    return invoke(clear = { it.clear() }) { Collections.synchronizedList(mutableListOf()) }
+public fun <T> MapMemory.mutableList(defaultValue: () -> List<T> = ::emptyList): MapMemoryProperty<MutableList<T>> {
+    return invoke(
+        clear = { list ->
+            synchronized(list) {
+                list.clear()
+                list.addAll(defaultValue())
+            }
+        },
+        defaultValue = { Collections.synchronizedList(defaultValue().toMutableList()) },
+    )
 }
 
 /**

--- a/mapmemory/src/test/kotlin/ReusablePropertiesTest.kt
+++ b/mapmemory/src/test/kotlin/ReusablePropertiesTest.kt
@@ -26,6 +26,21 @@ internal class ReusablePropertiesTest {
     }
 
     @Test
+    fun `when cleared memory containing mutable list - should keep the list and replace content with defaults`() {
+        val defaultList = listOf(0)
+        val list by memory.mutableList { defaultList }
+
+        // Keep the reference to the original list
+        val originalList = list
+        list += 1
+
+        memory.clear()
+
+        list shouldBe originalList
+        list.shouldContainExactly(defaultList)
+    }
+
+    @Test
     fun `when cleared memory containing mutable map - should keep the map and clear it`() {
         val map by memory.mutableMap<String, Int>()
 
@@ -38,6 +53,21 @@ internal class ReusablePropertiesTest {
 
         map shouldBe originalMap
         map shouldContainExactly mapOf("Answer" to 42)
+    }
+
+    @Test
+    fun `when cleared memory containing mutable map - should keep the map and replace content with defaults`() {
+        val defaultMap = mapOf("Answer" to 42)
+        val map by memory.mutableMap { defaultMap }
+
+        // Keep the reference to the original map
+        val originalMap = map
+        map["Zero"] = 0
+
+        memory.clear()
+
+        map shouldBe originalMap
+        map shouldContainExactly defaultMap
     }
 
     @Test


### PR DESCRIPTION
Added parameter `defaultValue` to most of reusable properties: `mutableList`, `mutableMap`, `reactiveMutableMap`, `behaviorSubject`.